### PR TITLE
Refine landing page copy and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1236,7 +1236,7 @@
                 <div class="benefit-item"><span class="tick">✓</span> <strong>18-Year Local Reputation</strong></div>
                 <div class="benefit-item"><span class="tick">✓</span> <strong>Complete Pricing Transparency</strong></div>
                 <div class="benefit-item"><span class="tick">✓</span> <strong>HETAS certified master engineers</strong></div>
-                <div class="benefit-item"><span class="tick">✓</span> <strong>UK's only stockist of all Britain's finest stoves</strong></div>
+                <div class="benefit-item"><span class="tick">✓</span> <strong>UK’s leading stockist of Britain’s finest stoves</strong></div>
             </div>
             
             <a href="#form" class="cta-primary">
@@ -1269,7 +1269,7 @@
                 
                 <p>The problem is, you've heard the horror stories: unreliable installers who cut corners, hidden costs that take you by surprise, and inferior workmanship that leaves you frustrated and cold. Too many homeowners have been let down by companies that promise the world but deliver headaches instead.</p>
                 
-                <p>That's why we've spent 18 years perfecting every detail of the fireplace installation process. From your initial consultation through final certification, we've eliminated the uncertainty, surprises, and stress that plague this industry. Our reputation has been built one satisfied customer at a time, with complete transparency and unwavering commitment to quality.</p>
+                <p>That's why we've spent 18 years perfecting every detail of the fireplace installation process. From your initial consultation through to final certification, we've eliminated the uncertainty, surprises, and stress that plague this industry. Our reputation has been built one satisfied customer at a time, with complete transparency and unwavering commitment to quality.</p>
             </div>
         </div>
     </div>
@@ -1291,7 +1291,7 @@
             <div class="pillar-card fade-in">
                 <div class="pillar-number">2</div>
                 <h3>18 Years of Excellence</h3>
-                <p>Since 2007, we've proudly served the Midlands with unwavering dedication. Every installation is personally project-managed from initial consultation through final certification.</p>
+                <p>Since 2007, we've proudly served the Midlands with unwavering dedication. Every installation is personally project-managed from initial consultation through to final certification.</p>
             </div>
             
             <div class="pillar-card fade-in">
@@ -1333,7 +1333,7 @@
             <div class="package-card fade-in interactive">
                 <img src="https://storage.googleapis.com/msgsndr/2y2XmPsJl1txt36sI8q3/media/68b81c7ad9dfddfc1c623cee.jpeg" alt="Complete Transformation - Twin-wall flue system installation" style="width: 100%; height: 240px; object-fit: cover; border-radius: 8px;">
                 <h3>Complete Transformation</h3>
-                <p>No existing chimney? No compromise. Our complete flue systems bring warmth and character to any space with architectural sensitivity.</p>
+                <p>No existing chimney? No compromise. Our complete stove &amp; flue systems bring warmth and character to any space with architectural sensitivity.</p>
                 <div class="price">From £4,500</div>
                 <p><em>Includes premium stove, engineered flue system, hearth preparation, certified installation</em></p>
             </div>
@@ -1341,8 +1341,8 @@
             <div class="package-card fade-in interactive">
                 <img src="https://storage.googleapis.com/msgsndr/2y2XmPsJl1txt36sI8q3/media/68b6ed04dd8003506e013c86.jpeg" alt="Modern Luxury - Bioethanol fireplace installation" style="width: 100%; height: 240px; object-fit: cover; border-radius: 8px;">
                 <h3>Modern Luxury</h3>
-                <p>Real flames without compromise. Bioethanol solutions for contemporary living—perfect for apartments, conservatories, and architectural statements.</p>
-                <div class="price">From £5,000</div>
+                <p>Real flames without the need for a flue—a true wood burner alternative for contemporary living. Perfect for apartments, conservatories, and architectural statements.</p>
+                <div class="price">From £5,500</div>
                 <p><em>Includes premium bioethanol unit, professional setup, app control, artisan fuel selection</em></p>
             </div>
         </div>
@@ -1525,7 +1525,7 @@
                     <img src="https://storage.googleapis.com/msgsndr/2y2XmPsJl1txt36sI8q3/media/68b6e9ca8b204258189951f0.jpeg" alt="Ebben & Yorke Showroom Interior" style="width: 100%; aspect-ratio: 1/1; object-fit: cover; border-radius: 12px; margin-bottom: 20px;">
                 </div>
                 <h3 style="font-family: 'Playfair Display', serif; font-size: 1.8rem; color: var(--forest); margin-bottom: 20px; text-align: center;">Visit Our Sutton Coldfield Showroom</h3>
-                <p style="text-align: center;">Many of our clients choose to visit our impressive showroom following their initial phone consultation. Here you can experience firsthand our curated collection of premium British and Scandinavian stoves, feel the quality of our materials, and discuss your vision with our expert team in person.</p>
+                <p style="text-align: center;">Many of our clients choose to visit our impressive showroom following their initial phone consultation. Here you can experience first-hand our curated collection of premium British and Scandinavian stoves, feel the quality of our materials, and discuss your vision with our expert team in person.</p>
                 <br>
                 <p style="text-align: center;"><strong>Location:</strong> 23 Mitchells, Weeford Road, Sutton Coldfield B75 6NA</p>
                 <p style="text-align: center;"><strong>Opening Hours:</strong> Monday to Saturday, 10:30am - 4:00pm</p>
@@ -1551,7 +1551,7 @@
                     <li>Uncertified installers</li>
                     <li>Limited warranty coverage</li>
                     <li>Inferior mass-produced stoves</li>
-                    <li>Compromise materials</li>
+                    <li>Compromised materials</li>
                 </ul>
                 <p style="margin-top: 20px;"><strong>The inevitable result:</strong> Remedial work, safety concerns, voided warranties, and disappointed expectations</p>
             </div>
@@ -1560,7 +1560,6 @@
                 <h3>The Ebben & Yorke Promise</h3>
                 <ul>
                     <li>Exclusive access to premium UK & European marques</li>
-                    <li>Britain's only complete premium collection</li>
                     <li>HETAS certified master craftsmen</li>
                     <li>All materials and components included</li>
                     <li>Engineered flue systems</li>
@@ -1657,7 +1656,7 @@
             Serving West Midlands, Staffordshire, Derbyshire & Leicestershire with distinction since 2007
         </p>
         <p style="margin-top: 20px; font-size: 0.8rem; opacity: 0.5;">
-            © Copyright Ebben & Yorke Retail Ltd. 2021. All rights reserved. Ebben & Yorke Retail Ltd. Registered in England & Wales. Reg No: 06247899. Registered Office: 6 Parkside Court, Greenhough Road, Lichfield WS13 7AU. VAT No: 992 3019 11 | <a href="https://s3.privyr.com/privacy/privacy-policy.html?d=eyJlbWFpbCI6Im9mZmljZUBlYmJlbmFuZHlvcmtlLmNvLnVrIiwiY29tcGFueSI6IkViYmVuICYgWW9ya2UiLCJnZW5fYXQiOiIyMDI1LTA5LTAyVDIwOjE5OjAwLjAxNloifQ==" target="_blank" style="color: rgba(255,255,255,0.6); text-decoration: underline;">Privacy Policy</a>
+            © Copyright Ebben & Yorke Retail Ltd. 2025. All rights reserved. Ebben & Yorke Retail Ltd. Registered in England & Wales. Reg No: 06247899. Registered Office: 6 Parkside Court, Greenhough Road, Lichfield WS13 7AU. VAT No: 992 3019 11 | <a href="https://s3.privyr.com/privacy/privacy-policy.html?d=eyJlbWFpbCI6Im9mZmljZUBlYmJlbmFuZHlvcmtlLmNvLnVrIiwiY29tcGFueSI6IkViYmVuICYgWW9ya2UiLCJnZW5fYXQiOiIyMDI1LTA5LTAyVDIwOjE5OjAwLjAxNloifQ==" target="_blank" style="color: rgba(255,255,255,0.6); text-decoration: underline;">Privacy Policy</a>
         </p>
     </div>
 </footer>


### PR DESCRIPTION
## Summary
- Replaced "only stockist" claim with "UK’s leading stockist" wording.
- Added "through to final certification" phrasing across trust and pillar sections and refreshed package descriptions and prices.
- Updated showroom wording, comparison list, and footer year while removing exclusivity claim.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bebd5828f0832e8d4c76e9b4306cd3