### PR TITLE
Standardize Lead event on calendar page

### DIFF
--- a/Calendar.html
+++ b/Calendar.html
@@ -17,7 +17,7 @@
     'https://connect.facebook.net/en_US/fbevents.js');
     fbq('init', '1202717601883540');
     fbq('track', 'PageView');
-    fbq('trackCustom', 'lead');
+    fbq('track', 'Lead');
     </script>
     <noscript><img height="1" width="1" style="display:none"
     src="https://www.facebook.com/tr?id=1202717601883540&ev=PageView&noscript=1"


### PR DESCRIPTION
## Summary
- Send Meta Pixel `Lead` event on the calendar page to match server-side standard

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4168faa70832eb98e376749ad3ede