### PR TITLE
Temporarily disable Calendar lead tracking

### DIFF
--- a/Calendar.html
+++ b/Calendar.html
@@ -17,7 +17,8 @@
     'https://connect.facebook.net/en_US/fbevents.js');
     fbq('init', '1202717601883540');
     fbq('track', 'PageView');
-    fbq('track', 'Lead');
+    // Temporarily disable automatic Lead event tracking due to Meta deduplication issues
+    // fbq('track', 'Lead');
     </script>
     <noscript><img height="1" width="1" style="display:none"
     src="https://www.facebook.com/tr?id=1202717601883540&ev=PageView&noscript=1"


### PR DESCRIPTION
## Summary
- comment out the automatic Meta Pixel Lead event on the Calendar page to prevent duplicate firing while troubleshooting CRM deduplication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c845b8de9c832e913a0311c993dee5